### PR TITLE
Add Guild Resource Locator to README and export in Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm start
 
 - **[Embed Factory](examples/utilities/embed-examples.ts)** - Creating rich embeds
 - **[Component Factory](examples/utilities/component-examples.ts)** - Building interactive components
+- **[Guild Resource Locator](examples/utilities/guild-resource-examples.ts)** - Fetching guild channels, roles, and members
 
 ---
 
@@ -210,6 +211,39 @@ const buttons = ComponentFactory.CreateHelpSectionButtons(
   interactionId,
   currentIndex
 );
+```
+
+**Guild Resource Locator:**
+
+```typescript
+import { CreateGuildResourceLocator } from "./Utilities";
+
+// Create a resource locator for a guild
+const locator = CreateGuildResourceLocator({
+  guild: interaction.guild,
+  logger: context.logger,
+});
+
+// Get channels easily
+const channel = await locator.GetChannel("123456789");
+const textChannel = await locator.GetTextChannel("123456789");
+const channelByName = await locator.GetChannelByName("general");
+
+// Get roles and members
+const role = await locator.GetRole("987654321");
+const member = await locator.GetMember("555666777");
+
+// Ensure resources exist (throws error if not found)
+const requiredChannel = await locator.EnsureTextChannel("123456789");
+const requiredRole = await locator.EnsureRole("987654321");
+
+// Channels are cached for 1 minute by default
+// Configure cache TTL:
+const locator = CreateGuildResourceLocator({
+  guild,
+  logger,
+  cacheTtlMs: 300_000, // 5 minutes
+});
 ```
 
 ### 📊 Logging

--- a/examples/utilities/guild-resource-examples.ts
+++ b/examples/utilities/guild-resource-examples.ts
@@ -1,0 +1,66 @@
+import { SlashCommandBuilder } from 'discord.js'
+import { CreateCommand } from '../../src/Commands/CommandFactory'
+import { CreateGuildResourceLocator } from '../../src/Utilities'
+
+async function ExecuteGuildResources(interaction: any, context: any): Promise<void> {
+  const { replyResponder } = context.responders
+  const { logger } = context
+
+  if (!interaction.guild) {
+    await replyResponder.Send(interaction, {
+      content: '❌ This command requires a guild context.',
+      ephemeral: true
+    })
+    return
+  }
+
+  try {
+    // Create a guild resource locator for easy access to guild resources
+    const locator = CreateGuildResourceLocator({
+      guild: interaction.guild,
+      logger,
+      cacheTtlMs: 120_000 // Cache for 2 minutes
+    })
+
+    // Get channels by ID or name
+    const channels = [
+      await locator.GetChannelByName('general'),
+      await locator.GetTextChannel(interaction.channelId),
+      await locator.GetChannelByName('announcements')
+    ].filter(Boolean)
+
+    // Get roles by name
+    const adminRole = await locator.GetRoleByName('admin')
+    const moderatorRole = await locator.GetRoleByName('moderator')
+
+    // Get members
+    const member = await locator.GetMember(interaction.user.id)
+
+    // Create embed with resource information
+    const content = `📊 **Guild Resources Found**\n\n**Channels:** ${channels.length} found\n**Roles:** ${[adminRole, moderatorRole].filter(Boolean).length} found\n**Current Member:** ${member ? 'Found' : 'Not found'}`
+
+    await replyResponder.Send(interaction, {
+      content,
+      ephemeral: true
+    })
+
+  } catch (error) {
+    logger.Error('Failed to gather guild resources', {
+      guildId: interaction.guild?.id,
+      userId: interaction.user.id,
+      error
+    })
+
+    await replyResponder.Send(interaction, {
+      content: '❌ Failed to gather guild resources.',
+      ephemeral: true
+    })
+  }
+}
+
+export const GuildResourceExample = CreateCommand({
+  name: 'guild-resources',
+  description: 'Find channels, roles, and members in the current guild',
+  group: 'utility',
+  execute: ExecuteGuildResources
+})

--- a/src/Utilities/GuildResourceLocator.ts
+++ b/src/Utilities/GuildResourceLocator.ts
@@ -1,0 +1,313 @@
+import {
+  CategoryChannel,
+  ChannelType,
+  Guild,
+  GuildBasedChannel,
+  GuildMember,
+  Role,
+  Snowflake,
+  TextChannel,
+  VoiceChannel
+} from 'discord.js'
+import { Logger } from '../Shared/Logger'
+
+interface CacheEntry<T> {
+  readonly value: T
+  readonly expiresAt: number
+}
+
+const DEFAULT_CACHE_TTL_MS = 60_000
+
+class ResourceCache<T> {
+  private readonly ttl: number
+  private readonly entries = new Map<string, CacheEntry<T>>()
+
+  constructor(ttl: number) {
+    this.ttl = Math.max(ttl, 0)
+  }
+
+  Get(key: string): T | undefined {
+    if (this.ttl === 0) {
+      return undefined
+    }
+
+    const entry = this.entries.get(key)
+    if (!entry) {
+      return undefined
+    }
+
+    if (Date.now() > entry.expiresAt) {
+      this.entries.delete(key)
+      return undefined
+    }
+
+    return entry.value
+  }
+
+  Set(key: string, value: T): void {
+    if (this.ttl === 0) {
+      return
+    }
+
+    this.entries.set(key, {
+      value,
+      expiresAt: Date.now() + this.ttl
+    })
+  }
+
+  Find(predicate: (value: T) => boolean): T | null {
+    if (this.ttl === 0) {
+      return null
+    }
+
+    const now = Date.now()
+
+    for (const [key, entry] of this.entries) {
+      if (now > entry.expiresAt) {
+        this.entries.delete(key)
+        continue
+      }
+
+      if (predicate(entry.value)) {
+        return entry.value
+      }
+    }
+
+    return null
+  }
+}
+
+export interface GuildResourceLocatorOptions {
+  readonly guild: Guild
+  readonly logger?: Logger
+  readonly cacheTtlMs?: number
+}
+
+export interface GuildResourceLocator {
+  GetChannel(id: Snowflake): Promise<GuildBasedChannel | null>
+  GetChannelByName(name: string): Promise<GuildBasedChannel | null>
+  GetTextChannel(id: Snowflake): Promise<TextChannel | null>
+  GetVoiceChannel(id: Snowflake): Promise<VoiceChannel | null>
+  GetCategoryChannel(id: Snowflake): Promise<CategoryChannel | null>
+  GetRole(id: Snowflake): Promise<Role | null>
+  GetRoleByName(name: string): Promise<Role | null>
+  GetMember(id: Snowflake): Promise<GuildMember | null>
+  EnsureChannel(id: Snowflake): Promise<GuildBasedChannel>
+  EnsureTextChannel(id: Snowflake): Promise<TextChannel>
+  EnsureRole(id: Snowflake): Promise<Role>
+  EnsureMember(id: Snowflake): Promise<GuildMember>
+}
+
+export function CreateGuildResourceLocator(options: GuildResourceLocatorOptions): GuildResourceLocator {
+  const cacheTtl = options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS
+  const channelCache = new ResourceCache<GuildBasedChannel>(cacheTtl)
+  const roleCache = new ResourceCache<Role>(cacheTtl)
+  const memberCache = new ResourceCache<GuildMember>(cacheTtl)
+
+  return {
+    GetChannel: id => _FetchChannel(options.guild, channelCache, options.logger, id),
+    GetChannelByName: name => _FetchChannelByName(options.guild, channelCache, options.logger, name),
+    GetTextChannel: async id => _FilterChannel(await _FetchChannel(options.guild, channelCache, options.logger, id), ChannelType.GuildText) as TextChannel | null,
+    GetVoiceChannel: async id => _FilterChannel(await _FetchChannel(options.guild, channelCache, options.logger, id), ChannelType.GuildVoice) as VoiceChannel | null,
+    GetCategoryChannel: async id => _FilterChannel(await _FetchChannel(options.guild, channelCache, options.logger, id), ChannelType.GuildCategory) as CategoryChannel | null,
+    GetRole: id => _FetchRole(options.guild, roleCache, options.logger, id),
+    GetRoleByName: name => _FetchRoleByName(options.guild, roleCache, options.logger, name),
+    GetMember: id => _FetchMember(options.guild, memberCache, options.logger, id),
+    EnsureChannel: async id => _EnsureResource(await _FetchChannel(options.guild, channelCache, options.logger, id), `Channel ${id} was not found in guild ${options.guild.id}`),
+    EnsureTextChannel: async id => _EnsureResource(await _FilterChannel(await _FetchChannel(options.guild, channelCache, options.logger, id), ChannelType.GuildText), `Text channel ${id} was not found in guild ${options.guild.id}`) as TextChannel,
+    EnsureRole: async id => _EnsureResource(await _FetchRole(options.guild, roleCache, options.logger, id), `Role ${id} was not found in guild ${options.guild.id}`),
+    EnsureMember: async id => _EnsureResource(await _FetchMember(options.guild, memberCache, options.logger, id), `Member ${id} was not found in guild ${options.guild.id}`)
+  }
+}
+
+async function _FetchChannel(
+  guild: Guild,
+  cache: ResourceCache<GuildBasedChannel>,
+  logger: Logger | undefined,
+  id: Snowflake
+): Promise<GuildBasedChannel | null> {
+  const cached = cache.Get(id)
+  if (cached) {
+    return cached
+  }
+
+  try {
+    const channel = await guild.channels.fetch(id)
+    if (!channel) {
+      return null
+    }
+
+    cache.Set(id, channel)
+    return channel
+  } catch (error) {
+    logger?.Warn('Failed to fetch guild channel', {
+      guildId: guild.id,
+      extra: { id },
+      error
+    })
+    return null
+  }
+}
+
+async function _FetchChannelByName(
+  guild: Guild,
+  cache: ResourceCache<GuildBasedChannel>,
+  logger: Logger | undefined,
+  name: string
+): Promise<GuildBasedChannel | null> {
+  const normalized = name.toLowerCase()
+
+  const cached = cache.Find(channel => 'name' in channel && channel.name?.toLowerCase() === normalized)
+  if (cached) {
+    return cached
+  }
+
+  const existing = guild.channels.cache.find(channel => 'name' in channel && channel.name.toLowerCase() === normalized) as GuildBasedChannel | undefined
+  if (existing) {
+    cache.Set(existing.id, existing)
+    return existing
+  }
+
+  try {
+    const channels = await guild.channels.fetch()
+    const match = channels.find(channel => channel && 'name' in channel && channel.name?.toLowerCase() === normalized) as GuildBasedChannel | undefined
+    if (!match) {
+      return null
+    }
+
+    cache.Set(match.id, match)
+    return match
+  } catch (error) {
+    logger?.Warn('Failed to fetch guild channels by name', {
+      guildId: guild.id,
+      extra: { name },
+      error
+    })
+    return null
+  }
+}
+
+async function _FetchRole(
+  guild: Guild,
+  cache: ResourceCache<Role>,
+  logger: Logger | undefined,
+  id: Snowflake
+): Promise<Role | null> {
+  const cached = cache.Get(id)
+  if (cached) {
+    return cached
+  }
+
+  const existing = guild.roles.cache.get(id)
+  if (existing) {
+    cache.Set(id, existing)
+    return existing
+  }
+
+  try {
+    const role = await guild.roles.fetch(id)
+    if (!role) {
+      return null
+    }
+
+    cache.Set(id, role)
+    return role
+  } catch (error) {
+    logger?.Warn('Failed to fetch guild role', {
+      guildId: guild.id,
+      extra: { id },
+      error
+    })
+    return null
+  }
+}
+
+async function _FetchRoleByName(
+  guild: Guild,
+  cache: ResourceCache<Role>,
+  logger: Logger | undefined,
+  name: string
+): Promise<Role | null> {
+  const normalized = name.toLowerCase()
+
+  const cached = cache.Find(role => role.name.toLowerCase() === normalized)
+  if (cached) {
+    return cached
+  }
+
+  const existing = guild.roles.cache.find(role => role.name.toLowerCase() === normalized)
+  if (existing) {
+    cache.Set(existing.id, existing)
+    return existing
+  }
+
+  try {
+    const roles = await guild.roles.fetch()
+    const match = roles.find(role => role.name.toLowerCase() === normalized)
+    if (!match) {
+      return null
+    }
+
+    cache.Set(match.id, match)
+    return match
+  } catch (error) {
+    logger?.Warn('Failed to fetch guild roles by name', {
+      guildId: guild.id,
+      extra: { name },
+      error
+    })
+    return null
+  }
+}
+
+async function _FetchMember(
+  guild: Guild,
+  cache: ResourceCache<GuildMember>,
+  logger: Logger | undefined,
+  id: Snowflake
+): Promise<GuildMember | null> {
+  const cached = cache.Get(id)
+  if (cached) {
+    return cached
+  }
+
+  const existing = guild.members.cache.get(id)
+  if (existing) {
+    cache.Set(id, existing)
+    return existing
+  }
+
+  try {
+    const member = await guild.members.fetch(id)
+    if (!member) {
+      return null
+    }
+
+    cache.Set(id, member)
+    return member
+  } catch (error) {
+    logger?.Warn('Failed to fetch guild member', {
+      guildId: guild.id,
+      extra: { id },
+      error
+    })
+    return null
+  }
+}
+
+function _FilterChannel(channel: GuildBasedChannel | null, expectedType: ChannelType): GuildBasedChannel | null {
+  if (!channel) {
+    return null
+  }
+
+  return channel.type === expectedType ? channel : null
+}
+
+function _EnsureResource<T>(resource: T | null, errorMessage: string): T {
+  if (!resource) {
+    throw new Error(errorMessage)
+  }
+
+  return resource
+}
+

--- a/src/Utilities/index.ts
+++ b/src/Utilities/index.ts
@@ -1,2 +1,3 @@
 export * from './EmbedBuilder'
 export * from './ComponentBuilder'
+export * from './GuildResourceLocator'


### PR DESCRIPTION
- Introduced a new section in the README for the Guild Resource Locator, detailing its functionality for fetching guild channels, roles, and members.
- Added example code demonstrating the usage of the Guild Resource Locator.
- Updated the Utilities index to export the new Guild Resource Locator for broader accessibility.